### PR TITLE
Loading textures in parallel

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,20 +9,20 @@ on:
 
 jobs:
   Build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     
-    - name: Install dependencies
-      shell: bash
-      run: |
-         sudo apt update
-         sudo apt install gcc-10
-         sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    # - name: Install dependencies
+    #   shell: bash
+      # run: |
+         # sudo apt update
+         # sudo apt install gcc-10
+         # sudo update-alternatives \
+         #  --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+         #  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+         #  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+         #  --slave /usr/bin/gcov gcov /usr/bin/gcov-10
     
     - name: Compile Renderer
       shell: bash

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,17 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    # - name: Install dependencies
-    #   shell: bash
-      # run: |
-         # sudo apt update
-         # sudo apt install gcc-10
-         # sudo update-alternatives \
-         #  --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-         #  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-         #  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-         #  --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-    
     - name: Compile Renderer
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ space           :=
 VPATH           := $(subst $(space),:,$(shell find . -type d))
 GCCFLAGS        := -std=gnu17 -Wall -Wextra -Werror -Wshadow -Wpedantic -Wnull-dereference -Wunused -Wconversion -Wno-pointer-sign
 
-ifeq ($(config), release)
-	GCCFLAGS +=  -O2
-else
+ifeq ($(config), debug)
 	GCCFLAGS +=  -g3 -pg -fsanitize=address,leak
+else
+	GCCFLAGS +=  -O2
 endif
 
 # TARGETS

--- a/src/file.c
+++ b/src/file.c
@@ -40,7 +40,8 @@ file_t* file_new(const char* file_path)
 
     // copy file contents into buffer
     unsigned char* buffer = malloc(file_size);
-    fread(buffer, sizeof(unsigned char), file_size, handle);
+    size_t result = fread(buffer, sizeof(unsigned char), file_size, handle);
+    assert((uint32_t)result == file_size);
 
     // close file as its no longer needed
     fclose(handle);

--- a/src/parsers/png.h
+++ b/src/parsers/png.h
@@ -3,4 +3,20 @@
 #include <stddef.h>
 #include "../texture.h"
 
-texture_t* parse_png(const unsigned char* buffer, uint32_t size);
+#define MAX_TEXTURE_LOAD_COUNT 10
+
+typedef struct
+{
+    uint32_t    size;
+    texture_t*  textures[MAX_TEXTURE_LOAD_COUNT];
+} texture_batch_t;
+
+typedef struct
+{
+    uint32_t             size;
+    uint32_t             buffer_sizes[MAX_TEXTURE_LOAD_COUNT];
+    const unsigned char* buffers[MAX_TEXTURE_LOAD_COUNT];
+} texture_batch_info_t;
+
+texture_t*      parse_png(const unsigned char* buffer, uint32_t size);
+texture_batch_t parse_multiple_pngs(texture_batch_info_t info);


### PR DESCRIPTION
- on top of the parse_png function there is now parse_multiple_pngs that takes in multiple raw buffers and parses them in parallel
- make with no arguments now builds with optimizations enabled. This is because multithreaded code is actually slower than single threaded code in debug builds