### PR TITLE
Bilinear texture filtering

### DIFF
--- a/src/math.c
+++ b/src/math.c
@@ -636,3 +636,18 @@ float f_cos(float v)
 {
     return cosf(v);
 }
+
+float f_floor(float v)
+{
+    return floorf(v);
+}
+
+float f_ceil(float v)
+{
+    return ceilf(v);
+}
+
+float f_round(float v)
+{
+    return roundf(v);
+}

--- a/src/math.h
+++ b/src/math.h
@@ -167,6 +167,9 @@ typedef struct
 float       f_abs(float a);
 float       f_min(float a, float b);
 float       f_max(float a, float b);
+float       f_ceil(float v);
+float       f_floor(float v);
+float       f_round(float v);
 int32_t     i_max(int32_t a, int32_t b);
 int32_t     i_min(int32_t a, int32_t b);
 uint32_t    u_max(uint32_t a, uint32_t b);

--- a/src/shader.c
+++ b/src/shader.c
@@ -53,15 +53,6 @@ static vec4_t vec4_mix(vec4_t v0, vec4_t v1, float mix)
     return vec4_new(x, y, z);
 }
 
-
-static uint32_t sample(texture_t* tex, float u, float v)
-{
-    uint32_t u_idx = (uint32_t)(u * (float)tex->width) - 1;
-    uint32_t v_idx = (uint32_t)(v * (float)tex->height) - 1;
-
-    return texture_get(tex, u_idx, v_idx);
-}
-
 // static vec4_t sample_normal(texture_t* tex, float u, float v)
 // {
 //     // fixme: this second sample method is needed because of the whole BGRA thing.
@@ -188,8 +179,8 @@ uint32_t shader_fragment(float w0, float w1, float w2)
     float s             = f_min(t0.x * w0 + t1.x * w1 + t2.x * w2, 1.f);
     float t             = f_min(t0.y * w0 + t1.y * w1 + t2.y * w2, 1.f);
 
-    vec4_t albedo       = vec4_scale(vec4_from_bgra(sample(albedo_texture, s, t)), 2.2f);
-    vec4_t metallic     = vec4_from_bgra(sample(metallic_texture, s, t));
+    vec4_t albedo       = vec4_scale(vec4_from_bgra(texture_sample(albedo_texture, s, t)), 2.2f);
+    vec4_t metallic     = vec4_from_bgra(texture_sample(metallic_texture, s, t));
     float rough         = metallic.y;                                       // green channel
     float metal         = metallic.x;                                       // blue channel
     // vec_t o             = vec_from_bgra(sample(tri->occlusion, s, t));

--- a/src/shader.c
+++ b/src/shader.c
@@ -179,8 +179,8 @@ uint32_t shader_fragment(float w0, float w1, float w2)
     float s             = f_min(t0.x * w0 + t1.x * w1 + t2.x * w2, 1.f);
     float t             = f_min(t0.y * w0 + t1.y * w1 + t2.y * w2, 1.f);
 
-    vec4_t albedo       = vec4_scale(vec4_from_bgra(texture_sample(albedo_texture, s, t)), 2.2f);
-    vec4_t metallic     = vec4_from_bgra(texture_sample(metallic_texture, s, t));
+    vec4_t albedo       = vec4_scale(texture_sample(albedo_texture, s, t), 2.2f);
+    vec4_t metallic     = texture_sample(metallic_texture, s, t);
     float rough         = metallic.y;                                       // green channel
     float metal         = metallic.x;                                       // blue channel
     // vec_t o             = vec_from_bgra(sample(tri->occlusion, s, t));

--- a/src/test/test_math_utils.c
+++ b/src/test/test_math_utils.c
@@ -193,6 +193,51 @@ static void test_f_wrap()
 }
 
 
+static void test_f_floor()
+{
+    float actual;
+    float expected;
+
+    actual = f_floor(3.2f);
+    expected = 3.f;
+    ASSERT_EQUAL(actual, expected);
+
+    actual = f_floor(-3.7f);
+    expected = -4.f;
+    ASSERT_EQUAL(actual, expected);
+}
+
+
+static void test_f_ceil()
+{
+    float actual;
+    float expected;
+
+    actual = f_ceil(3.2f);
+    expected = 4.f;
+    ASSERT_EQUAL(actual, expected);
+
+    actual = f_ceil(-3.7f);
+    expected = -3.f;
+    ASSERT_EQUAL(actual, expected);
+}
+
+
+static void test_f_round()
+{
+    float actual;
+    float expected;
+
+    actual = f_round(3.2f);
+    expected = 3.f;
+    ASSERT_EQUAL(actual, expected);
+
+    actual = f_ceil(-3.7f);
+    expected = -3.f;
+    ASSERT_EQUAL(actual, expected);
+}
+
+
 void test_math_utils()
 {
     TEST_CASE(test_f_abs);
@@ -204,4 +249,7 @@ void test_math_utils()
     TEST_CASE(test_u_max);
     TEST_CASE(test_f_clamp);
     TEST_CASE(test_f_wrap);
+    TEST_CASE(test_f_floor);
+    TEST_CASE(test_f_ceil);
+    TEST_CASE(test_f_round);
 }

--- a/src/texture.c
+++ b/src/texture.c
@@ -1,6 +1,47 @@
 #include "texture.h"
 
 #include <stdlib.h>
+#include <stdio.h>
+
+/********************
+ *  Notes
+ *
+ ********************/
+
+/********************/
+/*      defines     */
+/********************/
+
+/********************/
+/* static variables */
+/********************/
+
+// 0 - point, 1 - bilinear
+// TODO - 2 - trilinear, 3 - cubic, 4 - anisotropic
+static int32_t SAMPLING_METHOD = 1;
+
+/********************/
+/* static functions */
+/********************/
+
+static vec4_t sample(texture_t* texture, uint32_t x, uint32_t y)
+{
+    float w             = (float)texture->width;
+    uint32_t stride     = texture->stride;
+    unsigned char* data = texture->data;
+
+    uint32_t index      = (x + (uint32_t)w * y) * stride;
+    float d             = 1.f / 255.f;
+    float b             = (float)(data[index + 2] & 0xFF);
+    float g             = (float)(data[index + 1] & 0xFF);
+    float r             = (float)(data[index + 0] & 0xFF);
+
+    return vec4_new(b * d, g * d, r * d);
+}
+
+/********************/
+/* public functions */
+/********************/
 
 texture_t* texture_new(uint32_t width, uint32_t height, uint32_t stride)
 {
@@ -16,17 +57,45 @@ vec4_t texture_sample(texture_t* texture, float u, float v)
 {
     // this function converts rgba from image to bgra
 
-    uint32_t x          = (uint32_t)(u * (float)texture->width) - 1;
-    uint32_t y          = (uint32_t)(v * (float)texture->height) - 1;
-    uint32_t index      = (x + texture->width * y) * texture->stride;
-    unsigned char* data = texture->data;
+    float w             = (float)texture->width;
+    float h             = (float)texture->height;
+    vec4_t result = vec4_new(1.f, 0.f, 1.f);
 
-    float d = 1.f / 255.f;
-    float b = (float)(data[index + 2] & 0xFF);
-    float g = (float)(data[index + 1] & 0xFF);
-    float r = (float)(data[index + 0] & 0xFF);
+    if (SAMPLING_METHOD == 0)
+    {
+        uint32_t x = (uint32_t)f_floor(u * w);
+        uint32_t y = (uint32_t)f_floor(v * h);
+        result = sample(texture, x, y);
+    }
+    else if (SAMPLING_METHOD == 1)
+    {
+        float x = u * w;
+        float y = v * h;
+        float x1 = f_floor(u * w);
+        float x2 = x1 + 1.f;
+        float y1 = f_floor(v * h);
+        float y2 = y1 + 1.f;
 
-    return vec4_new(b * d, g * d, r * d);
+        vec4_t f_x1y1 = sample(texture, (uint32_t)x1, (uint32_t)y1);
+        vec4_t f_x1y2 = sample(texture, (uint32_t)x1, (uint32_t)y2);
+        vec4_t f_x2y1 = sample(texture, (uint32_t)x2, (uint32_t)y1);
+        vec4_t f_x2y2 = sample(texture, (uint32_t)x2, (uint32_t)y2);
+
+        vec4_t f_xy1_1  = vec4_scale(f_x1y1, (x2 - x) / (x2 - x1));
+        vec4_t f_xy1_2  = vec4_scale(f_x2y1, (x - x1) / (x2 - x1));
+        vec4_t f_xy1    = vec4_add(f_xy1_1, f_xy1_2);
+
+        vec4_t f_xy2_1  = vec4_scale(f_x1y2, (x2 - x) / (x2 - x1));
+        vec4_t f_xy2_2  = vec4_scale(f_x2y2, (x - x1) / (x2 - x1));
+        vec4_t f_xy2    = vec4_add(f_xy2_1, f_xy2_2);
+
+        vec4_t f_xy_1   = vec4_scale(f_xy1, (y2 - y) / (y2 - y1) );
+        vec4_t f_xy_2   = vec4_scale(f_xy2, (y - y1) / (y2 - y1) );
+
+        result = vec4_add(f_xy_1, f_xy_2);
+    }
+
+    return result;
 }
 
 void texture_free(texture_t* texture)

--- a/src/texture.c
+++ b/src/texture.c
@@ -12,24 +12,21 @@ texture_t* texture_new(uint32_t width, uint32_t height, uint32_t stride)
 	return texture;
 }
 
-uint32_t texture_sample(texture_t* texture, float u, float v)
+vec4_t texture_sample(texture_t* texture, float u, float v)
 {
-    // TODO: BGRA vs RGBA????? GOOD PLACE FOR BOUNDRY? Loader / texture / screen ? ????
+    // this function converts rgba from image to bgra
+
     uint32_t x          = (uint32_t)(u * (float)texture->width) - 1;
     uint32_t y          = (uint32_t)(v * (float)texture->height) - 1;
     uint32_t index      = (x + texture->width * y) * texture->stride;
     unsigned char* data = texture->data;
 
-    uint32_t result = 0;
-    result += data[index + 0] << 8;     // R
-    result += data[index + 1] << 16;    // G
-    result += data[index + 2] << 24;    // B
-    if (texture->stride == 4)
-    {
-        result += data[index + 3];          // A
-    }
+    float d = 1.f / 255.f;
+    float b = (float)(data[index + 2] & 0xFF);
+    float g = (float)(data[index + 1] & 0xFF);
+    float r = (float)(data[index + 0] & 0xFF);
 
-    return result;
+    return vec4_new(b * d, g * d, r * d);
 }
 
 void texture_free(texture_t* texture)

--- a/src/texture.c
+++ b/src/texture.c
@@ -12,11 +12,12 @@ texture_t* texture_new(uint32_t width, uint32_t height, uint32_t stride)
 	return texture;
 }
 
-uint32_t texture_get(texture_t* texture, uint32_t x, uint32_t y)
+uint32_t texture_sample(texture_t* texture, float u, float v)
 {
     // TODO: BGRA vs RGBA????? GOOD PLACE FOR BOUNDRY? Loader / texture / screen ? ????
-
-    uint32_t index = (x + texture->width * y) * texture->stride;
+    uint32_t x          = (uint32_t)(u * (float)texture->width) - 1;
+    uint32_t y          = (uint32_t)(v * (float)texture->height) - 1;
+    uint32_t index      = (x + texture->width * y) * texture->stride;
     unsigned char* data = texture->data;
 
     uint32_t result = 0;

--- a/src/texture.h
+++ b/src/texture.h
@@ -11,5 +11,5 @@ typedef struct
 } texture_t;
 
 texture_t*  texture_new(uint32_t width, uint32_t height, uint32_t stride);
-uint32_t    texture_get(texture_t* texture, uint32_t x, uint32_t y);
+uint32_t    texture_sample(texture_t* texture, float u, float v);
 void        texture_free(texture_t* texture);

--- a/src/texture.h
+++ b/src/texture.h
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 
+#include "math.h"
+
 typedef struct
 {
 	uint32_t width;
@@ -11,5 +13,5 @@ typedef struct
 } texture_t;
 
 texture_t*  texture_new(uint32_t width, uint32_t height, uint32_t stride);
-uint32_t    texture_sample(texture_t* texture, float u, float v);
+vec4_t      texture_sample(texture_t* texture, float u, float v);
 void        texture_free(texture_t* texture);


### PR DESCRIPTION
This PR adds Bilinear texture sampling. It is completely unoptimized, will probably do it as part of milestone 0.3. Ive also added a new issue to cover Trilinear/Cubic/Anisotropic sampling once mip maps are added. From what i read on wikipedia, their main advantage is related to mipmaps so ill postpone implementation.

Additionally, ive added `f_floor/f_round/f_ceil` math utils